### PR TITLE
[CUMULUS-2479] Add version endpoint to docs

### DIFF
--- a/content/version.md
+++ b/content/version.md
@@ -1,0 +1,22 @@
+## Versioning
+
+The Cumulus API is versioned and the current version is v1. Retrieve the latest API version from Cumulus.
+
+```endpoint
+GET /version
+```
+
+To use any version, include the version number in the path before the query endpoint. `{API_URL}/{version}/{query}`
+
+#### Example Request
+```curl
+$ curl https://example.com/version
+```
+
+#### Example Response
+```json
+{
+    "response_version": "v1",
+    "api_version": "1.1.1"
+}
+```

--- a/content/version.md
+++ b/content/version.md
@@ -1,6 +1,6 @@
 ## Versioning
 
-The Cumulus API is versioned and the current version is v1. Retrieve the latest API version from Cumulus.
+The Cumulus Distribution API is versioned and the current version is v1. Retrieve the latest API version from Cumulus.
 
 ```endpoint
 GET /version

--- a/template/src/custom/content.js
+++ b/template/src/custom/content.js
@@ -21,4 +21,7 @@ module.exports =
   fs.readFileSync('./content/s3credentials.md', 'utf8') + '\n' +
 
   '# S3 Access README\n' +
-  fs.readFileSync('./content/s3credentialsreadme.md', 'utf8') + '\n';
+  fs.readFileSync('./content/s3credentialsreadme.md', 'utf8') + '\n' +
+
+  '# Version\n' +
+  fs.readFileSync('./content/version.md', 'utf8') + '\n';

--- a/template/src/custom/content.js
+++ b/template/src/custom/content.js
@@ -14,6 +14,9 @@ module.exports =
   '# Introduction\n' +
   fs.readFileSync('./content/introduction.md', 'utf8') + '\n' +
 
+  '# Versioning\n' +
+  fs.readFileSync('./content/version.md', 'utf8') + '\n' +
+
   '# Data Access\n' +
   fs.readFileSync('./content/distribution.md', 'utf8') + '\n' +
 
@@ -21,7 +24,4 @@ module.exports =
   fs.readFileSync('./content/s3credentials.md', 'utf8') + '\n' +
 
   '# S3 Access README\n' +
-  fs.readFileSync('./content/s3credentialsreadme.md', 'utf8') + '\n' +
-
-  '# Version\n' +
-  fs.readFileSync('./content/version.md', 'utf8') + '\n';
+  fs.readFileSync('./content/s3credentialsreadme.md', 'utf8') + '\n';


### PR DESCRIPTION
Used the info from here: https://nasa.github.io/cumulus-api/#versioning-1 since it uses the same method.